### PR TITLE
ship only necessary files

### DIFF
--- a/minitest-hooks.gemspec
+++ b/minitest-hooks.gemspec
@@ -1,7 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'minitest-hooks'
   s.version = '1.1.0'
-  s.platform = Gem::Platform::RUBY
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc", "CHANGELOG", "MIT-LICENSE"]
   s.rdoc_options += ["--quiet", "--line-numbers", "--inline-source", '--title', 'minitest-hooks: around and before_all/after_all/around_all hooks for Minitest', '--main', 'README.rdoc']
@@ -10,7 +9,7 @@ spec = Gem::Specification.new do |s|
   s.author = "Jeremy Evans"
   s.email = "code@jeremyevans.net"
   s.homepage = "http://github.com/jeremyevans/minitest-hooks"
-  s.files = %w(MIT-LICENSE CHANGELOG README.rdoc Rakefile) + Dir["{spec,lib}/**/*.rb"]
+  s.files = %w(MIT-LICENSE README.rdoc) + Dir["lib/**/*.rb"]
   s.description = <<END
 minitest-hooks adds around and before_all/after_all/around_all hooks for Minitest.
 This allows you do things like run each suite of specs inside a database transaction,


### PR DESCRIPTION
@jeremyevans very few people open gems and even fewer need any of these files -> optimize for that 99.x% usecase and reduce filesize on disk + size of vendored gems