### PR TITLE
prevent overwriting with multiple hooks and add an easy way to define…

### DIFF
--- a/lib/minitest/hooks.rb
+++ b/lib/minitest/hooks.rb
@@ -81,27 +81,35 @@ module Minitest::Hooks::ClassMethods
 
   # If type is :all, set the before_all hook instead of the before hook.
   def before(type=nil, &block)
-    if type == :all
+    case type
+    when :all
      define_method(:before_all) do
         super()
         instance_exec(&block)
       end
       nil
+    when :module
+      include Module.new { define_method(:setup) { super(); instance_exec(&block) } }
     else
-      super
+      raise "setup is already defined in this class" if instance_methods(false).include?(:setup)
+      super()
     end
   end
 
   # If type is :all, set the after_all hook instead of the after hook.
   def after(type=nil, &block)
-    if type == :all
+    case type
+    when :all
      define_method(:after_all) do
         instance_exec(&block)
         super()
       end
       nil
+    when :module
+      include Module.new { define_method(:teardown) { instance_exec(&block); super() } }
     else
-      super
+      raise "teardown is already defined in this class" if instance_methods(false).include?(:teardown)
+      super()
     end
   end
 end

--- a/spec/minitest_hooks_spec.rb
+++ b/spec/minitest_hooks_spec.rb
@@ -106,3 +106,27 @@ describe 'Minitest::Hooks with transactions/savepoints' do
     end
   end
 end
+
+describe "multiple hooks" do
+  let(:list) { [] }
+  before(:module) { list << 1 }
+  before { list << 2 }
+  begin
+    before { list << 3 }
+  rescue RuntimeError
+  else
+    raise "That should not have worked"
+  end
+  after { list << 4 }
+  after(:module) { list.must_equal [1,2,4] }
+  begin
+    after { list << 6 }
+  rescue RuntimeError
+  else
+    raise "That should not have worked"
+  end
+
+  it "works" do
+    list.must_equal [1,2]
+  end
+end


### PR DESCRIPTION
… multiple hooks

@jeremyevans 

 - blow up nicely when trying to use multiple blocks (splitting them for readability or by having test macros)
 - add easy way to add multiple hooks