### PR TITLE
Don't load minitest/spec in main file

### DIFF
--- a/lib/minitest/hooks.rb
+++ b/lib/minitest/hooks.rb
@@ -1,5 +1,3 @@
-require 'minitest/spec'
-
 # Add support for around and before_all/after_all/around_all hooks to
 # minitest spec classes.
 module Minitest::Hooks
@@ -104,9 +102,4 @@ module Minitest::Hooks::ClassMethods
       super
     end
   end
-end
-
-# Spec subclass that includes the hook methods.
-class Minitest::HooksSpec < Minitest::Spec
-  include Minitest::Hooks
 end

--- a/lib/minitest/hooks/default.rb
+++ b/lib/minitest/hooks/default.rb
@@ -1,3 +1,9 @@
 require 'minitest/hooks'
+require 'minitest/spec'
+
+# Spec subclass that includes the hook methods.
+class Minitest::HooksSpec < Minitest::Spec
+  include Minitest::Hooks
+end
 
 MiniTest::Spec.register_spec_type(//, Minitest::HooksSpec)


### PR DESCRIPTION
Avoid loading minitest/spec when requiring `minitest/hooks`, because minitest/test users probably don't want minitest/spec to be required, since it does a lot of moneky-patching.

The functionality should stay the same for the majority of use cases, because requiring `minitest/hooks` itself still doesn't add `Minitest::Hooks` it to `Minitest::Spec`, only `minitest/hooks/default` does.