### PR TITLE
prevent Rails crash by setting method name for singleton instance

### DIFF
--- a/lib/minitest/hooks/test.rb
+++ b/lib/minitest/hooks/test.rb
@@ -75,6 +75,7 @@ module Minitest::Hooks::ClassMethods
 
           if @instance.failure
             failed = true
+            @instance.name = :before_all
             reporter.record @instance
           else
             super(reporter, &block)
@@ -85,6 +86,7 @@ module Minitest::Hooks::ClassMethods
           end
           if @instance.failure && !failed
             failed = true
+            @instance.name = :after_all
             reporter.record @instance
           end
           inside = false
@@ -94,6 +96,7 @@ module Minitest::Hooks::ClassMethods
       @instance.capture_exceptions do
         raise e
       end
+      @instance.name = :around_all
       reporter.record @instance
     end
   end


### PR DESCRIPTION
When using this gem with Rails, if an error is raised inside a hook, it causes a crash when Rails tries to report the method name where the error occurred.  This appears to happen because the value of `@instance.name` is the `NEW` object.  If `@instance.name` is instead set to the name of the executing hook method, Rails can report the method name successfully.

This script demonstrates the crash:

```
mkdir minitest-hooks-test
cd minitest-hooks-test/

rbenv exec gem install rails -v 5.0.3
rbenv exec rails new .

cat >>Gemfile <<EOF
gem 'minitest-hooks', git: 'https://github.com/jeremyevans/minitest-hooks.git'
# gem 'minitest-hooks', git: 'git@github.com:rcrogers/minitest-hooks.git'
EOF
rbenv exec bundle install

cat >test/integration/foo_test.rb <<EOF
class FooTest < ActiveSupport::TestCase
  include Minitest::Hooks
  
  def before_all
    super
    raise 'a problem'
  end

  def test_foo
    assert_equal 1, 1
  end
end
EOF

rbenv exec bundle exec rake test
```

Resulting in this output:
```
Run options: --seed 42541

# Running:

E

Error:
FooTest##<Object:0x007fcffc69a540>:
RuntimeError: a problem
    test/integration/foo_test.rb:6:in `before_all'

E

Error:
FooTest##<Object:0x007fcffc69a540>:
RuntimeError: a problem
    test/integration/foo_test.rb:6:in `before_all'

Error:
FooTest##<Object:0x007fcffc69a540>:
TypeError: #<Object:0x007fcffc69a540> is not a symbol nor a string

/Users/rcrogers/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-5.1.2/lib/rails/test_unit/reporter.rb:70:in `method': #<Object:0x007fcffc69a540> is not a symbol nor a string (TypeError)
        from /Users/rcrogers/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-5.1.2/lib/rails/test_unit/reporter.rb:70:in `format_rerun_snippet'
        ...
```

After swapping the commented lines in the `Gemfile`:
```
Run options: --seed 22799

# Running:

E

Error:
FooTest#before_all:
RuntimeError: a problem
    test/integration/foo_test.rb:6:in `before_all'

bin/rails test test/integration/foo_test.rb:4

Finished in 0.001694s, 590.3187 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```