### PR TITLE
Ensure exceptions in before/after/around all hooks do not break reporters

### DIFF
--- a/lib/minitest/hooks/test.rb
+++ b/lib/minitest/hooks/test.rb
@@ -63,6 +63,7 @@ module Minitest::Hooks::ClassMethods
   # dup of the singleton instance.
   def with_info_handler(reporter, &block)
     @instance = new(NEW)
+    @instance.time = 0
     inside = false
    
     begin

--- a/spec/minitest_hooks_errors_spec.rb
+++ b/spec/minitest_hooks_errors_spec.rb
@@ -8,7 +8,7 @@ describe 'Minitest::Hooks error handling' do
   def self.run_test(desc, runs, errors)
     it "should handle errors in #{desc}" do
       ENV['MINITEST_HOOKS_ERRORS'] = desc
-      Open3.popen3(RUBY, "spec/errors/example.rb") do  |_, o, e, w|
+      Open3.popen3(RUBY, "spec/errors/example.rb", "-v") do  |_, o, e, w|
         o.read.must_match /#{runs} runs, 0 assertions, 0 failures, #{errors} errors, 0 skips/
         e.read.must_equal ''
         w.value.exitstatus.wont_equal 0 if w


### PR DESCRIPTION
Say you have a test case like so:

```
class BadTest
  before(:all) do |&block|
    raise 'boom'
  end

  it 'sad' do
  end
end
```

If you run this in Rails, you'll get something like this:

```
/Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/railties-5.1.3/lib/rails/test_unit/reporter.rb:66:in `%': can't convert nil into Float (TypeError)
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/railties-5.1.3/lib/rails/test_unit/reporter.rb:66:in `format_line'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/railties-5.1.3/lib/rails/test_unit/reporter.rb:13:in `record'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-reporters-1.1.15/lib/minitest/minitest_reporter_plugin.rb:21:in `block in record'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-reporters-1.1.15/lib/minitest/minitest_reporter_plugin.rb:20:in `each'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-reporters-1.1.15/lib/minitest/minitest_reporter_plugin.rb:20:in `record'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-5.10.3/lib/minitest.rb:682:in `block in record'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-5.10.3/lib/minitest.rb:681:in `each'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-5.10.3/lib/minitest.rb:681:in `record'
	from /Users/sday/src/minitest-hooks/lib/minitest/hooks/test.rb:100:in `rescue in with_info_handler'
	from /Users/sday/src/minitest-hooks/lib/minitest/hooks/test.rb:68:in `with_info_handler'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-5.10.3/lib/minitest.rb:309:in `run'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/railties-5.1.3/lib/rails/test_unit/line_filtering.rb:9:in `run'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-5.10.3/lib/minitest.rb:159:in `block in __run'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-5.10.3/lib/minitest.rb:159:in `map'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-5.10.3/lib/minitest.rb:159:in `__run'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-5.10.3/lib/minitest.rb:136:in `run'
	from /Users/sday/.rvm/gems/ruby-2.4.1@status-page/gems/minitest-5.10.3/lib/minitest.rb:63:in `block in autorun'
```

The problem is the Rails reporter, (and the default [minitest](https://github.com/seattlerb/minitest/blob/master/lib/minitest.rb#L497) + [minitest-reporters](https://github.com/kern/minitest-reporters/blob/master/lib/minitest/reporters/default_reporter.rb#L59) ones) is that they expect time to never be nil. So we poke a 0 in there in case we hit the rescue case.

There's probably a better way to solve this, but I have no clue what I'm doing, so here we are.
