### PR TITLE
Fix Minitest 6 deprecation warnings

### DIFF
--- a/spec/errors/example.rb
+++ b/spec/errors/example.rb
@@ -52,11 +52,11 @@ describe 'Minitest::Hooks error handling' do
     super(&block)
     case error
     when 'before-all'
-      name.must_equal 'before_all'
+      _(name).must_equal 'before_all'
     when 'after-all'
-      name.must_equal 'after_all'
+      _(name).must_equal 'after_all'
     else
-      name.must_equal 'around_all'
+      _(name).must_equal 'around_all'
     end
     raise if error == 'around-all-after'
   end

--- a/spec/minitest_hooks_all_name_spec.rb
+++ b/spec/minitest_hooks_all_name_spec.rb
@@ -3,15 +3,15 @@ require 'minitest/hooks/default'
 
 describe 'Minitest::Hooks error handling' do
   before(:all) do
-    name.must_equal 'before_all'
+    _(name).must_equal 'before_all'
   end
   after(:all) do
-    name.must_equal 'after_all'
+    _(name).must_equal 'after_all'
   end
   around(:all) do |&block|
-    name.must_equal 'around_all'
+    _(name).must_equal 'around_all'
     super(&block)
-    name.must_equal 'around_all'
+    _(name).must_equal 'around_all'
   end
 
   3.times do |i|

--- a/spec/minitest_hooks_direct_spec.rb
+++ b/spec/minitest_hooks_direct_spec.rb
@@ -10,45 +10,45 @@ describe 'Minitest::Hooks with transactions/savepoints no_default' do
 
   before(:all) do
     @ds_ba = @ds_aa
-    @ds_ba.count.must_equal 1 + @i
+    _(@ds_ba.count).must_equal 1 + @i
   end
   before do
     @ds_be = @ds_ae
-    @ds_be.count.must_equal 2 + @i * 2
+    _(@ds_be.count).must_equal 2 + @i * 2
   end
   after do
-    @ds_be.count.must_equal 2 + @i * 2
+    _(@ds_be.count).must_equal 2 + @i * 2
   end
   after(:all) do
-    @ds_ba.count.must_equal 1 + @i
+    _(@ds_ba.count).must_equal 1 + @i
   end
   around do |&block|
-    @ds_aa.count.must_equal 1 + @i
+    _(@ds_aa.count).must_equal 1 + @i
     NDB.transaction(:rollback=>:always, :savepoint=>true, :auto_savepoint=>true) do
       @ds_ae = @ds_aa
       @ds_ae.insert(1)
       super(&block)
     end
-    @ds_aa.count.must_equal 1 + @i
+    _(@ds_aa.count).must_equal 1 + @i
   end
   around(:all) do |&block|
     @i ||= 0
     NDB.transaction(:rollback=>:always) do
       NDB.create_table(:a){Integer :a}
       @ds_aa = NDB[:a]
-      @ds_aa.count.must_equal 0
+      _(@ds_aa.count).must_equal 0
       @ds_aa.insert(1)
       super(&block)
     end
-    NDB.table_exists?(:a).must_equal false
+    _(NDB.table_exists?(:a)).must_equal false
   end
 
   3.times do |i|
     it "should work try #{i}" do
-      @ds_aa.count.must_equal 2
-      @ds_ae.count.must_equal 2
-      @ds_ba.count.must_equal 2
-      @ds_be.count.must_equal 2
+      _(@ds_aa.count).must_equal 2
+      _(@ds_ae.count).must_equal 2
+      _(@ds_ba.count).must_equal 2
+      _(@ds_be.count).must_equal 2
     end
   end
 
@@ -56,56 +56,56 @@ describe 'Minitest::Hooks with transactions/savepoints no_default' do
     before(:all) do
       @ds_ba3 = @ds_ba
       @ds_ba2 = @ds_aa2
-      @ds_ba2.count.must_equal 2
+      _(@ds_ba2.count).must_equal 2
     end
     before do
       @ds_be3 = @ds_be
       @ds_be2 = @ds_ae2
-      @ds_be2.count.must_equal 4
+      _(@ds_be2.count).must_equal 4
     end
     after do
-      @ds_be2.count.must_equal 4
+      _(@ds_be2.count).must_equal 4
     end
     after(:all) do
-      @ds_ba2.count.must_equal 2
+      _(@ds_ba2.count).must_equal 2
     end
     around do |&block|
-      @ds_aa.count.must_equal 2
+      _(@ds_aa.count).must_equal 2
       super() do
-        @ds_aa.count.must_equal 3
+        _(@ds_aa.count).must_equal 3
         @ds_ae3 = @ds_ae
         @ds_ae2 = @ds_aa2
         @ds_ae2.insert(1)
         block.call
-        @ds_aa.count.must_equal 4
+        _(@ds_aa.count).must_equal 4
       end
-      @ds_aa.count.must_equal 2
+      _(@ds_aa.count).must_equal 2
     end
     around(:all) do |&block|
       @i ||= 1
       super() do
-        @ds_aa.count.must_equal 1
+        _(@ds_aa.count).must_equal 1
         @ds_aa2 = @ds_aa
         @ds_aa2.insert(1)
         block.call
-        @ds_aa.count.must_equal 2
+        _(@ds_aa.count).must_equal 2
       end
-      NDB.table_exists?(:a).must_equal false
+      _(NDB.table_exists?(:a)).must_equal false
     end
 
     3.times do |i|
       it "should work try #{i}" do
-        @ds_aa.count.must_equal 4
-        @ds_ae.count.must_equal 4
-        @ds_ba.count.must_equal 4
-        @ds_be.count.must_equal 4
-        @ds_aa2.count.must_equal 4
-        @ds_ae2.count.must_equal 4
-        @ds_ba2.count.must_equal 4
-        @ds_be2.count.must_equal 4
-        @ds_ae3.count.must_equal 4
-        @ds_ba3.count.must_equal 4
-        @ds_be3.count.must_equal 4
+        _(@ds_aa.count).must_equal 4
+        _(@ds_ae.count).must_equal 4
+        _(@ds_ba.count).must_equal 4
+        _(@ds_be.count).must_equal 4
+        _(@ds_aa2.count).must_equal 4
+        _(@ds_ae2.count).must_equal 4
+        _(@ds_ba2.count).must_equal 4
+        _(@ds_be2.count).must_equal 4
+        _(@ds_ae3.count).must_equal 4
+        _(@ds_ba3.count).must_equal 4
+        _(@ds_be3.count).must_equal 4
       end
     end
   end

--- a/spec/minitest_hooks_errors_spec.rb
+++ b/spec/minitest_hooks_errors_spec.rb
@@ -10,13 +10,13 @@ describe 'Minitest::Hooks error handling' do
       ENV['MINITEST_HOOKS_ERRORS'] = desc
       Open3.popen3(RUBY, "spec/errors/example.rb", "-v") do  |_, o, e, w|
         output = o.read
-        output.must_match /#{runs} runs, 0 assertions, 0 failures, #{errors} errors, 0 skips/
-        output.must_match /result to_s: ".*?Minitest::Hooks error handling#\w+.*?spec\/errors\/example\.rb:\d+/
-        output.must_match /result source_location: \["(unknown|.+?\.rb)", -?\d+\]/
+        _(output).must_match /#{runs} runs, \d+ assertions, 0 failures, #{errors} errors, 0 skips/
+        _(output).must_match /result to_s: ".*?Minitest::Hooks error handling#\w+.*?spec\/errors\/example\.rb:\d+/
+        _(output).must_match /result source_location: \["(unknown|.+?\.rb)", -?\d+\]/
         output = e.read
         output.gsub!(/Picked up _JAVA_OPTIONS: [^\n]+\n/, '')
-        output.must_equal ''
-        w.value.exitstatus.wont_equal 0 if w
+        _(output).must_equal ''
+        _(w.value.exitstatus).wont_equal 0 if w
       end
     end
   end

--- a/spec/minitest_hooks_spec.rb
+++ b/spec/minitest_hooks_spec.rb
@@ -6,45 +6,45 @@ DB = Sequel.connect(DATABASE_URL)
 describe 'Minitest::Hooks with transactions/savepoints' do
   before(:all) do
     @ds_ba = @ds_aa
-    @ds_ba.count.must_equal 1 + @i
+    _(@ds_ba.count).must_equal 1 + @i
   end
   before do
     @ds_be = @ds_ae
-    @ds_be.count.must_equal 2 + @i * 2
+    _(@ds_be.count).must_equal 2 + @i * 2
   end
   after do
-    @ds_be.count.must_equal 2 + @i * 2
+    _(@ds_be.count).must_equal 2 + @i * 2
   end
   after(:all) do
-    @ds_ba.count.must_equal 1 + @i
+    _(@ds_ba.count).must_equal 1 + @i
   end
   around do |&block|
-    @ds_aa.count.must_equal 1 + @i
+    _(@ds_aa.count).must_equal 1 + @i
     DB.transaction(:rollback=>:always, :savepoint=>true, :auto_savepoint=>true) do
       @ds_ae = @ds_aa
       @ds_ae.insert(1)
       super(&block)
     end
-    @ds_aa.count.must_equal 1 + @i
+    _(@ds_aa.count).must_equal 1 + @i
   end
   around(:all) do |&block|
     @i ||= 0
     DB.transaction(:rollback=>:always) do
       DB.create_table(:a){Integer :a}
       @ds_aa = DB[:a]
-      @ds_aa.count.must_equal 0
+      _(@ds_aa.count).must_equal 0
       @ds_aa.insert(1)
       super(&block)
     end
-    DB.table_exists?(:a).must_equal false
+    _(DB.table_exists?(:a)).must_equal false
   end
 
   3.times do |i|
     it "should work try #{i}" do
-      @ds_aa.count.must_equal 2
-      @ds_ae.count.must_equal 2
-      @ds_ba.count.must_equal 2
-      @ds_be.count.must_equal 2
+      _(@ds_aa.count).must_equal 2
+      _(@ds_ae.count).must_equal 2
+      _(@ds_ba.count).must_equal 2
+      _(@ds_be.count).must_equal 2
     end
   end
 
@@ -52,56 +52,56 @@ describe 'Minitest::Hooks with transactions/savepoints' do
     before(:all) do
       @ds_ba3 = @ds_ba
       @ds_ba2 = @ds_aa2
-      @ds_ba2.count.must_equal 2
+      _(@ds_ba2.count).must_equal 2
     end
     before do
       @ds_be3 = @ds_be
       @ds_be2 = @ds_ae2
-      @ds_be2.count.must_equal 4
+      _(@ds_be2.count).must_equal 4
     end
     after do
-      @ds_be2.count.must_equal 4
+      _(@ds_be2.count).must_equal 4
     end
     after(:all) do
-      @ds_ba2.count.must_equal 2
+      _(@ds_ba2.count).must_equal 2
     end
     around do |&block|
-      @ds_aa.count.must_equal 2
+      _(@ds_aa.count).must_equal 2
       super() do
-        @ds_aa.count.must_equal 3
+        _(@ds_aa.count).must_equal 3
         @ds_ae3 = @ds_ae
         @ds_ae2 = @ds_aa2
         @ds_ae2.insert(1)
         block.call
-        @ds_aa.count.must_equal 4
+        _(@ds_aa.count).must_equal 4
       end
-      @ds_aa.count.must_equal 2
+      _(@ds_aa.count).must_equal 2
     end
     around(:all) do |&block|
       @i ||= 1
       super() do
-        @ds_aa.count.must_equal 1
+        _(@ds_aa.count).must_equal 1
         @ds_aa2 = @ds_aa
         @ds_aa2.insert(1)
         block.call
-        @ds_aa.count.must_equal 2
+        _(@ds_aa.count).must_equal 2
       end
-      DB.table_exists?(:a).must_equal false
+      _(DB.table_exists?(:a)).must_equal false
     end
 
     3.times do |i|
       it "should work try #{i}" do
-        @ds_aa.count.must_equal 4
-        @ds_ae.count.must_equal 4
-        @ds_ba.count.must_equal 4
-        @ds_be.count.must_equal 4
-        @ds_aa2.count.must_equal 4
-        @ds_ae2.count.must_equal 4
-        @ds_ba2.count.must_equal 4
-        @ds_be2.count.must_equal 4
-        @ds_ae3.count.must_equal 4
-        @ds_ba3.count.must_equal 4
-        @ds_be3.count.must_equal 4
+        _(@ds_aa.count).must_equal 4
+        _(@ds_ae.count).must_equal 4
+        _(@ds_ba.count).must_equal 4
+        _(@ds_be.count).must_equal 4
+        _(@ds_aa2.count).must_equal 4
+        _(@ds_ae2.count).must_equal 4
+        _(@ds_ba2.count).must_equal 4
+        _(@ds_be2.count).must_equal 4
+        _(@ds_ae3.count).must_equal 4
+        _(@ds_ba3.count).must_equal 4
+        _(@ds_be3.count).must_equal 4
       end
     end
   end


### PR DESCRIPTION
Minitest 5.12.0 and later deprecated use of global expectations and prints a warning that these will stop working in Minitest 6.

Note that in addition to the fix recommended in the deprecation warning -- wrapping objects in `_(obj)` -- I had to change the pattern in `spec/minitest_hooks_errors_spec.rb` to `\d+ assertions`. I am not sure why this stopped matching but afaict the assertions count is not relevant in this test.