### PR TITLE
Make `with_info_handler` take rest args to fix upstream arity change

### DIFF
--- a/lib/minitest/hooks/test.rb
+++ b/lib/minitest/hooks/test.rb
@@ -61,11 +61,13 @@ module Minitest::Hooks::ClassMethods
   # When running the specs in the class, first create a singleton instance, the singleton is
   # used to implement around_all/before_all/after_all hooks, and each spec will run as a
   # dup of the singleton instance.
-  def with_info_handler(reporter, &block)
+  def with_info_handler(*args, &block)
     @instance = new(NEW)
     @instance.time = 0
     @instance.name = "around_all"
-   
+
+    reporter, *_ = args
+
     begin
       @instance.around_all do
         begin
@@ -78,7 +80,7 @@ module Minitest::Hooks::ClassMethods
             failed = true
             _record_minitest_hooks_error(reporter, @instance)
           else
-            super(reporter, &block)
+            super
           end
         ensure
           @instance.capture_exceptions do


### PR DESCRIPTION
Fixes #27 

The upstream `with_info_handler` method was changed to take an extra parameter, which is now breaking the implementation of the method in this gem. This commit fixes the issue by making the method take rest arguments, which will allow it to work with the upstream changes, and any other positional arguments that might be added in the future.